### PR TITLE
Move language switch button further left

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -1296,7 +1296,7 @@ footer a:hover {
 .header-lang-switch {
   position: absolute;
   top: 8px;
-  right: 68px;
+  right: 120px;
   display: flex;
   align-items: center;
   gap: 6px;

--- a/styles.css
+++ b/styles.css
@@ -1296,7 +1296,7 @@ footer a:hover {
 .header-lang-switch {
   position: absolute;
   top: 8px;
-  right: 120px;
+  right: 100px;
   display: flex;
   align-items: center;
   gap: 6px;


### PR DESCRIPTION
## Purpose
Based on user feedback, the language switch button was positioned too far to the right and was overlapping with other elements. Users requested moving the button further to the left to improve the layout and prevent visual conflicts.

## Code changes
- Updated `.header-lang-switch` CSS positioning
- Changed `right` property from `68px` to `100px` to move the language switch button 32px further to the left
- This adjustment provides better spacing and prevents the button from overlapping with adjacent elementsTo clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 14`

🔗 [Edit in Builder.io](https://builder.io/app/projects/5a3906f263e6460597539e982bf9e6c0/vortex-studio)

👀 [Preview Link](https://5a3906f263e6460597539e982bf9e6c0-vortex-studio.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>5a3906f263e6460597539e982bf9e6c0</projectId>-->
<!--<branchName>vortex-studio</branchName>-->